### PR TITLE
Fix overflowing databases list at bottom

### DIFF
--- a/css/navigation.css.php
+++ b/css/navigation.css.php
@@ -31,7 +31,6 @@ $navLineColor = '#222';
 #pma_navigation_header {
     overflow: hidden;
     background: <?php echo $GLOBALS['cfg']['HeaderBackground']; ?>;
-    padding-bottom: 1em;
     margin-bottom: .5em;
     -moz-box-shadow: 5px 8px 10px rgba(0,0,0,0.15);
     -webkit-box-shadow: 5px 8px 10px rgba(0,0,0,0.15);
@@ -85,7 +84,7 @@ $navLineColor = '#222';
 #pma_navigation #databaseList,
 #pma_navigation div.pageselector.dbselector {
     text-align: center;
-    padding: 1em 0;
+    padding: 1em 0 0 0;
     border: 0;
 }
 #navipanellinks {


### PR DESCRIPTION
Small fix to resolve an issue where you lose one row on the databases list at the bottom.

**Before:**
![image](https://user-images.githubusercontent.com/2490360/195858116-578a0c40-975f-4dcf-8557-1f1ceb29bd88.png)

**After:**
![image](https://user-images.githubusercontent.com/2490360/195858246-f38f8e0d-4a7d-4d9f-bf68-69bc3ce71c97.png)

**Headers now looks like this**
![image](https://user-images.githubusercontent.com/2490360/195858996-14709109-6eab-4bd8-ab48-284a49d55e5d.png)
